### PR TITLE
Allow using a custom printer for serialization of json messages

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,6 +1,5 @@
 rules = [
   RemoveUnused
-  ExplicitResultTypes
   DisableSyntax
   LeakingImplicitClassVal
   NoValInForComprehension
@@ -8,10 +7,10 @@ rules = [
 ]
 
 DisableSyntax.noVars = true
-DisableSyntax.noThrows = true
-DisableSyntax.noNulls = true
+DisableSyntax.noThrows = false
+DisableSyntax.noNulls = false
 DisableSyntax.noReturns = true
-DisableSyntax.noAsInstanceOf = true
+DisableSyntax.noAsInstanceOf = false
 DisableSyntax.noIsInstanceOf = true
 DisableSyntax.noXml = true
 DisableSyntax.noFinalVal = true

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ or
 
 ```scala
 import org.apache.kafka.streams.scala.StreamsBuilder
-
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.Serdes._
 import com.goyeau.kafka.streams.circe.CirceSerdes._
@@ -37,13 +36,11 @@ object Streams extends App {
 }
 ```
 
-If you need to customize the json serialization, a instance of CirceSerdes
-can be imported with a custom printer.
+If you need to customize the json serialization, a custom implicit instance of `Printer` can be provided in scope.
 
-For example, in the code below a custom printer is used to omit null values
+For example, in the code below a custom printer is used to omit null values:
 ```scala
 import org.apache.kafka.streams.scala.StreamsBuilder
-
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.Serdes._
 import com.goyeau.kafka.streams.circe.CirceSerdes._
@@ -52,12 +49,7 @@ import io.circe.generic.auto._
 case class Person(firstname: String, lastname: String, age: Int)
 
 object Streams extends App {
-  println("Starting streams")
-  val serdes = CirceSerdes(Printer(
-   dropNullValues = true,
-   indent = ""
-  ))
-  import serdes._
+  implicit val printer = Printer.noSpaces.copy(dropNullValues = true)
 
   val streamsBuilder = new StreamsBuilder
   val testStream = streamsBuilder.stream[String, Person]("some-topic")

--- a/README.md
+++ b/README.md
@@ -36,3 +36,31 @@ object Streams extends App {
   val testStream = streamsBuilder.stream[String, Person]("some-topic")
 }
 ```
+
+If you need to customize the json serialization, a instance of CirceSerdes
+can be imported with a custom printer.
+
+For example, in the code below a custom printer is used to omit null values
+```scala
+import org.apache.kafka.streams.scala.StreamsBuilder
+
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.Serdes._
+import com.goyeau.kafka.streams.circe.CirceSerdes._
+import io.circe.generic.auto._
+
+case class Person(firstname: String, lastname: String, age: Int)
+
+object Streams extends App {
+  println("Starting streams")
+  val serdes = CirceSerdes(Printer(
+   dropNullValues = true,
+   indent = ""
+  ))
+  import serdes._
+
+  val streamsBuilder = new StreamsBuilder
+  val testStream = streamsBuilder.stream[String, Person]("some-topic")
+}
+```
+

--- a/kafka-streams-circe/src/com/goyeau/kafka/streams/circe/CirceSerdes.scala
+++ b/kafka-streams-circe/src/com/goyeau/kafka/streams/circe/CirceSerdes.scala
@@ -1,31 +1,15 @@
 package com.goyeau.kafka.streams.circe
 
+import io.circe.parser._
+import io.circe.{Decoder, Encoder, Printer}
 import java.nio.charset.StandardCharsets
 import java.util
-
-import io.circe.parser._
-import io.circe.{Decoder, Encoder}
 import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.{Deserializer, Serde, Serdes, Serializer}
 
-/**
- * By default json is serialized using Printer.noSpaces.
- *
- * If you want to custom serialization, instead of import CirceSerdes you could write something like:
- *
- * <pre>
- * val serdes = CirceSerdes(Printer(
- *  dropNullValues = true,
- *  indent = ""
- * ))
- * import serdes._
- * </pre>
- *
- * @param printer
- */
-class CirceSerdes(printer: Printer) {
+object CirceSerdes {
 
-  implicit def serializer[T: Encoder]: Serializer[T] =
+  implicit def serializer[T: Encoder](implicit printer: Printer = Printer.noSpaces): Serializer[T] =
     new Serializer[T] {
       override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
       override def serialize(topic: String, caseClass: T): Array[Byte] =
@@ -45,8 +29,4 @@ class CirceSerdes(printer: Printer) {
     }
 
   implicit def serde[CC: Encoder: Decoder]: Serde[CC] = Serdes.serdeFrom(serializer, deserializer)
-}
-
-object CirceSerdes extends CirceSerdes(Printer.noSpaces) {
-  def apply(printer: Printer) = new CirceSerdes(printer)
 }


### PR DESCRIPTION
For my usecase, I wanted to remove Null values from Json messages during serialization. By default the noSpaces printer was used, I've made some changes to allow a custom printer as well.
Existing code should still work.